### PR TITLE
Minor fix

### DIFF
--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/ui/screens/detail/DetailActivity.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/ui/screens/detail/DetailActivity.kt
@@ -30,6 +30,7 @@ import com.antonioleiva.bandhookkotlin.ui.entity.mapper.ArtistDetailDataMapper
 import com.antonioleiva.bandhookkotlin.ui.presenter.DetailPresenter
 import com.antonioleiva.bandhookkotlin.ui.util.getNavigationId
 import com.antonioleiva.bandhookkotlin.ui.util.supportsLollipop
+import com.antonioleiva.bandhookkotlin.ui.util.setTransitionGroupCompat
 import com.antonioleiva.bandhookkotlin.ui.view.DetailView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
@@ -55,6 +56,8 @@ class DetailActivity : BaseActivity(), DetailView, ScrollableHeaderActivity,
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportsLollipop { image.transitionName = BaseActivity.IMAGE_TRANSITION_NAME }
+
+        findViewById(android.R.id.content).setTransitionGroupCompat(true)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/ui/util/ViewExtensions.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/ui/util/ViewExtensions.kt
@@ -17,7 +17,10 @@
 package com.antonioleiva.bandhookkotlin.ui.util
 
 import android.animation.ObjectAnimator
+import android.os.Build
+import android.support.v4.view.ViewGroupCompat
 import android.view.View
+import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.Interpolator
@@ -40,4 +43,13 @@ fun View.animateTranslationY(translationY: Int, interpolator: Interpolator) {
  */
 fun View.singleClick(l: (android.view.View?) -> Unit){
     setOnClickListener(SingleClickListener(l))
+}
+
+fun View.setTransitionGroupCompat(isTransitionGroup: Boolean) {
+    if (this is ViewGroup) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            setTransitionGroup(isTransitionGroup)
+        else
+            ViewGroupCompat.setTransitionGroup(this, isTransitionGroup)
+    }
 }


### PR DESCRIPTION
When clicking the list item, the app was constantly crashing on my phone with this exception:

```
03-25 00:13:01.539 5860-5993/com.antonioleiva.bandhookkotlin W/OpenGLRenderer: Layer exceeds max. dimensions supported by the GPU (1080x7160, max=4096x4096)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: JNI CallVoidMethodV called with pending exception 'java.lang.IllegalStateException' thrown in void android.os.MessageQueue.nativePollOnce(long, int):-2
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]     in call to CallVoidMethodV
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]     from void android.os.MessageQueue.nativePollOnce(long, int)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65] "main" prio=5 tid=1 Runnable
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   | group="main" sCount=0 dsCount=0 obj=0x75bc9040 self=0xb7852a70
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   | sysTid=5860 nice=0 cgrp=apps sched=0/0 handle=0xb6f1c058
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   | state=R schedstat=( 0 0 0 ) utm=43 stm=12 core=0 HZ=100
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   | stack=0xbe5a9000-0xbe5ab000 stackSize=8MB
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   | held mutexes= "mutator lock"(shared held)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #00 pc 00004828  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+23)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #01 pc 00002ec5  /system/lib/libbacktrace_libc++.so (Backtrace::Unwind(unsigned int, ucontext*)+8)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #02 pc 0024437d  /system/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, char const*, art::mirror::ArtMethod*)+68)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #03 pc 0022774b  /system/lib/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) const+394)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #04 pc 000af2db  /system/lib/libart.so (art::JniAbort(char const*, char const*)+582)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #05 pc 000afa21  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+60)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #06 pc 000b2b9b  /system/lib/libart.so (art::ScopedCheck::ScopedCheck(_JNIEnv*, int, char const*)+1286)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #07 pc 000ba05f  /system/lib/libart.so (art::CheckJNI::CallVoidMethodV(_JNIEnv*, _jobject*, _jmethodID*, std::__va_list)+30)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #08 pc 00060283  /system/lib/libandroid_runtime.so (???)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #09 pc 000746d1  /system/lib/libandroid_runtime.so (android::NativeDisplayEventReceiver::dispatchVsync(long long, int, unsigned int)+40)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #10 pc 0007494f  /system/lib/libandroid_runtime.so (android::NativeDisplayEventReceiver::handleEvent(int, int, void*)+142)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #11 pc 00013f07  /system/lib/libutils.so (android::Looper::pollInner(int)+594)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #12 pc 00013fc9  /system/lib/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+92)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #13 pc 000803fd  /system/lib/libandroid_runtime.so (android::NativeMessageQueue::pollOnce(_JNIEnv*, int)+22)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   native: #14 pc 000b1e37  /data/dalvik-cache/arm/system@framework@boot.oat (Java_android_os_MessageQueue_nativePollOnce__JI+102)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at android.os.MessageQueue.nativePollOnce(Native method)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at android.os.MessageQueue.next(MessageQueue.java:153)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at android.os.Looper.loop(Looper.java:131)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at android.app.ActivityThread.main(ActivityThread.java:5696)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at java.lang.reflect.Method.invoke!(Native method)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at java.lang.reflect.Method.invoke(Method.java:372)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1028)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65]   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:823)
03-25 00:13:01.589 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/check_jni.cc:65] 
03-25 00:13:01.979 5860-5860/com.antonioleiva.bandhookkotlin A/art: art/runtime/runtime.cc:284] Runtime aborting...
```

Used this answer to fix it: http://stackoverflow.com/a/26638729.
I couldn't find a way to do that via xml since `android:transitionGroup` was introduced in Lollipop.
