### PR TITLE
null check for LastFmArtist.mbid

### DIFF
--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
@@ -34,7 +34,7 @@ class ArtistMapper {
             artist.bio?.content)
 
     private fun artistHasQualityInfo(it: LastFmArtist): Boolean {
-        return !it.mbid.isEmpty() && it.images.size > 0
+        return it.mbid != null && !it.mbid.isEmpty() && it.images.size > 0
     }
 
     private fun getImage(images: List<LastFmImage>): String {


### PR DESCRIPTION
Was getting my feet wet with Kotlin and stumbled upon your app.  Trying to get it to run, I notice the similar artist query was failing with a NPE.  The cause was null mbid from Last FM, so isEmpty() was failing in your predicate.

```
LastFmArtist(name='Nothing But Thieves', mbid='null', url='http://www.last.fm/music/Nothing+But+Thieves', images=[com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@e0a17d4, com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@f86ed7d, com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@47d6472, com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@2ab0c3, com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@ddadd40, com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage@519e479], similar=null, bio=null)
```

After inserting a null check in your filter predicate resolved the issue, but Studio is now complaining about mbid not being nullable.  If I set mbid's type  to String?, Artist creation has a problem with Artist.id type being non-nullable.  Making it nullable didn't seem right.  Was wondering how you would fix this one?
