### PR TITLE
Handle nullable mbid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,6 @@ dependencies {
     compile "com.path:android-priority-jobqueue:1.1.2"
     compile "org.jetbrains.anko:anko-sdk15:$parent.ext.ankoVersion"
     compile "org.jetbrains.anko:anko-support-v4:$parent.ext.ankoVersion"
+
+    testCompile "junit:junit:4.12"
 }

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/data/CloudArtistDataSet.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/data/CloudArtistDataSet.kt
@@ -29,7 +29,7 @@ public class CloudArtistDataSet(val language: String, val lastFmService: LastFmS
         return ArtistMapper().transform(result.similarArtists.artists)
     }
 
-    override fun requestArtist(id: String): Artist {
+    override fun requestArtist(id: String): Artist? {
         val result = lastFmService.requestArtistInfo(id, language)
         return ArtistMapper().transform(result.artist)
     }

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/data/lastfm/model/LastFmArtist.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/data/lastfm/model/LastFmArtist.kt
@@ -20,7 +20,7 @@ import com.google.gson.annotations.SerializedName
 
 class LastFmArtist (
         val name: String,
-        val mbid: String,
+        val mbid: String?,
         val url: String,
         @SerializedName("image") val images: List<LastFmImage>,
         val similar: LastFmSimilar?,

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
@@ -24,20 +24,30 @@ import com.antonioleiva.bandhookkotlin.domain.entity.Artist
 class ArtistMapper {
 
     fun transform(artists: List<LastFmArtist>): List<Artist> {
-        return artists.filter { artistHasQualityInfo(it) }.map { transform(it) }
+        return artists.filter { artistHasQualityInfo(it) }.mapNotNull { transform(it) }
     }
 
-    fun transform(artist: LastFmArtist): Artist = Artist(
-            artist.mbid,
-            artist.name,
-            getImage(artist.images),
-            artist.bio?.content)
+    fun transform(artist: LastFmArtist): Artist? {
+        if (artist.mbid != null) {
+            return Artist(
+                    artist.mbid,
+                    artist.name,
+                    getImageUrl(artist.images),
+                    artist.bio?.content)
+        } else {
+            return null
+        }
+    }
 
     private fun artistHasQualityInfo(it: LastFmArtist): Boolean {
-        return !it.mbid.isEmpty() && it.images.size > 0
+        return !isArtistMbidEmpty(it) && it.images.size > 0
     }
 
-    private fun getImage(images: List<LastFmImage>): String {
+    private fun isArtistMbidEmpty(artist: LastFmArtist): Boolean {
+        return artist.mbid?.isEmpty() ?: true
+    }
+
+    private fun getImageUrl(images: List<LastFmImage>): String {
         val image = images.firstOrNull { it.size == LastFmImageType.MEGA.type }
         return image?.url ?: images.last().url
     }

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapper.kt
@@ -27,16 +27,8 @@ class ArtistMapper {
         return artists.filter { artistHasQualityInfo(it) }.mapNotNull { transform(it) }
     }
 
-    fun transform(artist: LastFmArtist): Artist? {
-        if (artist.mbid != null) {
-            return Artist(
-                    artist.mbid,
-                    artist.name,
-                    getImageUrl(artist.images),
-                    artist.bio?.content)
-        } else {
-            return null
-        }
+    fun transform(artist: LastFmArtist) = artist.mbid?.let {
+            Artist(artist.mbid, artist.name, getImageUrl(artist.images), artist.bio?.content)
     }
 
     private fun artistHasQualityInfo(it: LastFmArtist): Boolean {

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/repository/ArtistRepositoryImp.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/repository/ArtistRepositoryImp.kt
@@ -34,10 +34,11 @@ class ArtistRepositoryImp(val artistDataSets: List<ArtistDataSet>) : ArtistRepos
     }
 
     override fun getArtist(id: String): Artist {
-        // TODO test if result can be null
         for (dataSet in artistDataSets) {
             var result = dataSet.requestArtist(id)
-            return result;
+            if (result != null) {
+                return result;
+            }
         }
         return Artist("empty", "empty", "empty")
     }

--- a/app/src/main/java/com/antonioleiva/bandhookkotlin/repository/dataset/ArtistDataSet.kt
+++ b/app/src/main/java/com/antonioleiva/bandhookkotlin/repository/dataset/ArtistDataSet.kt
@@ -18,8 +18,8 @@ package com.antonioleiva.bandhookkotlin.repository.dataset
 
 import com.antonioleiva.bandhookkotlin.domain.entity.Artist
 
-public interface ArtistDataSet {
+interface ArtistDataSet {
 
     fun requestRecommendedArtists(): List<Artist>
-    fun requestArtist(id: String): Artist
+    fun requestArtist(id: String): Artist?
 }

--- a/app/src/test/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapperTest.kt
+++ b/app/src/test/java/com/antonioleiva/bandhookkotlin/data/mapper/ArtistMapperTest.kt
@@ -1,0 +1,91 @@
+package com.antonioleiva.bandhookkotlin.data.mapper
+
+import com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmArtist
+import com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmBio
+import com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImage
+import com.antonioleiva.bandhookkotlin.data.lastfm.model.LastFmImageType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * @author tpom6oh@gmail.com
+ * *         29/06/16.
+ */
+class ArtistMapperTest {
+    lateinit var artistMapper: ArtistMapper
+    lateinit var artistsList: List<LastFmArtist>
+    lateinit var validLastFmArtistWithMegaImage: LastFmArtist
+    lateinit var validLastFmArtistWithoutMegaImage: LastFmArtist
+    lateinit var invalidLastFmArtist: LastFmArtist
+    lateinit var megaLastFmImage: LastFmImage
+    lateinit var smallLastFmImage: LastFmImage
+
+    private val coldplayBio = LastFmBio("British rock band formed in 1996")
+    private val megaImageUrl = "megaImageOneUrl"
+    private val smallImageUrl = "smallImageOneUrl"
+
+    @Before
+    fun setUp() {
+        megaLastFmImage = LastFmImage(megaImageUrl, LastFmImageType.MEGA.type)
+        smallLastFmImage = LastFmImage(smallImageUrl, LastFmImageType.SMALL.type)
+
+        validLastFmArtistWithMegaImage = LastFmArtist("Coldplay", "mbid", "someurl",
+                listOf(megaLastFmImage, smallLastFmImage), null, coldplayBio)
+        validLastFmArtistWithoutMegaImage = LastFmArtist("Him", "mbid", "someurl",
+                listOf(smallLastFmImage, smallLastFmImage), null, null)
+        invalidLastFmArtist = LastFmArtist("Unknown", null, "someurl",
+                listOf(megaLastFmImage, smallLastFmImage), null, null)
+
+        artistsList = listOf(validLastFmArtistWithMegaImage,
+                             invalidLastFmArtist,
+                             validLastFmArtistWithoutMegaImage)
+
+        artistMapper = ArtistMapper()
+    }
+
+    @Test
+    fun testTransformArtists() {
+        // When
+        val artists = artistMapper.transform(artistsList)
+
+        // Then
+        assertEquals(2, artists.size)
+        assertEquals(validLastFmArtistWithMegaImage.mbid, artists[0].id)
+        assertEquals(validLastFmArtistWithoutMegaImage.mbid, artists[1].id)
+    }
+
+    @Test
+    fun testTransformArtist_ValidArtistWithMegaImage() {
+        // When
+        val artist = artistMapper.transform(validLastFmArtistWithMegaImage)
+
+        // Then
+        assertEquals(validLastFmArtistWithMegaImage.mbid, artist?.id)
+        assertEquals(validLastFmArtistWithMegaImage.name, artist?.name)
+        assertEquals(validLastFmArtistWithMegaImage.bio?.content, artist?.bio)
+        assertEquals(megaImageUrl, artist?.url)
+    }
+
+    @Test
+    fun testTransformArtist_ValidArtistWithoutMegaImage() {
+        // When
+        val artist = artistMapper.transform(validLastFmArtistWithoutMegaImage)
+
+        // Then
+        assertEquals(validLastFmArtistWithoutMegaImage.mbid, artist?.id)
+        assertEquals(validLastFmArtistWithoutMegaImage.name, artist?.name)
+        assertEquals(validLastFmArtistWithoutMegaImage.bio?.content, artist?.bio)
+        assertEquals(smallImageUrl, artist?.url)
+    }
+
+    @Test
+    fun testTransformArtist_InvalidArtist() {
+        // When
+        val artist = artistMapper.transform(invalidLastFmArtist)
+
+        // Then
+        assertNull(artist)
+    }
+}


### PR DESCRIPTION
## Description

I, as well as @alanwgeorge, noticed that the app does not work because one of the artists in the demo set does not have 'mbid'. Since this field is used to fetch additional data about the artist I think that the best solution is to drop artists that do not have this field set.

Plus I've added some tests for ArtistMapper.
