### PR TITLE
Unit Tests Fix

### DIFF
--- a/app/src/test/java/com/antonioleiva/bandhookkotlin/data/CloudAlbumDataSetTest.kt
+++ b/app/src/test/java/com/antonioleiva/bandhookkotlin/data/CloudAlbumDataSetTest.kt
@@ -19,6 +19,7 @@ package com.antonioleiva.bandhookkotlin.data
 import com.antonioleiva.bandhookkotlin.data.lastfm.LastFmService
 import com.antonioleiva.bandhookkotlin.data.lastfm.model.*
 import com.antonioleiva.bandhookkotlin.data.mapper.AlbumMapper
+import com.antonioleiva.bandhookkotlin.data.mock.FakeCall
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -26,6 +27,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.runners.MockitoJUnitRunner
+import retrofit2.Response
 
 @RunWith(MockitoJUnitRunner::class)
 class CloudAlbumDataSetTest {
@@ -64,8 +66,8 @@ class CloudAlbumDataSetTest {
         lastFmResponse = LastFmResponse(LastFmResult(LastFmArtistMatches(emptyList())), artist, topAlbums, LastFmArtistList(emptyList()),
                 knownAlbumDetail)
 
-        `when`(lastFmService.requestAlbum(albumMbid)).thenReturn(lastFmResponse)
-        `when`(lastFmService.requestAlbums(anyString(), anyString())).thenReturn(lastFmResponse)
+        `when`(lastFmService.requestAlbum(albumMbid)).thenReturn(FakeCall(Response.success(lastFmResponse), null))
+        `when`(lastFmService.requestAlbums(anyString(), anyString())).thenReturn(FakeCall(Response.success(lastFmResponse), null))
     }
 
     @Test
@@ -83,7 +85,7 @@ class CloudAlbumDataSetTest {
         // Given
         val unknownAlbumResponse = LastFmResponse(LastFmResult(LastFmArtistMatches(emptyList())), artist, topAlbums,
                 LastFmArtistList(emptyList()), unknownAlbumDetail)
-        `when`(lastFmService.requestAlbum(albumMbid)).thenReturn(unknownAlbumResponse)
+        `when`(lastFmService.requestAlbum(albumMbid)).thenReturn(FakeCall(Response.success(unknownAlbumResponse), null))
 
         // When
         val album = cloudAlbumDataSet.requestAlbum(albumMbid)

--- a/app/src/test/java/com/antonioleiva/bandhookkotlin/data/CloudArtistDataSetTest.kt
+++ b/app/src/test/java/com/antonioleiva/bandhookkotlin/data/CloudArtistDataSetTest.kt
@@ -19,6 +19,7 @@ package com.antonioleiva.bandhookkotlin.data
 import com.antonioleiva.bandhookkotlin.data.lastfm.LastFmService
 import com.antonioleiva.bandhookkotlin.data.lastfm.model.*
 import com.antonioleiva.bandhookkotlin.data.mapper.ArtistMapper
+import com.antonioleiva.bandhookkotlin.data.mock.FakeCall
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -28,6 +29,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.mockito.runners.MockitoJUnitRunner
+import retrofit2.Response
 
 @RunWith(MockitoJUnitRunner::class)
 class CloudArtistDataSetTest {
@@ -60,8 +62,8 @@ class CloudArtistDataSetTest {
 
         cloudArtistDataSet = CloudArtistDataSet(language, lastFmService)
 
-        `when`(lastFmService.requestSimilar(cloudArtistDataSet.coldplayMbid)).thenReturn(lastFmResponse)
-        `when`(lastFmService.requestArtistInfo(artistMbid, language)).thenReturn(lastFmResponse)
+        `when`(lastFmService.requestSimilar(cloudArtistDataSet.coldplayMbid)).thenReturn(FakeCall(Response.success(lastFmResponse), null))
+        `when`(lastFmService.requestArtistInfo(artistMbid, language)).thenReturn(FakeCall(Response.success(lastFmResponse), null))
     }
 
     @Test
@@ -92,7 +94,7 @@ class CloudArtistDataSetTest {
                 LastFmArtist("unknown artist name", null, "unknown artist url"),
                 LastFmTopAlbums(emptyList()),
                 LastFmArtistList(emptyList()), lastFmAlbumDetail)
-        `when`(lastFmService.requestArtistInfo(unknownArtisMbid, language)).thenReturn(unknownArtistResponse)
+        `when`(lastFmService.requestArtistInfo(unknownArtisMbid, language)).thenReturn(FakeCall(Response.success(unknownArtistResponse), null))
 
         // When
         val requestedArtist = cloudArtistDataSet.requestArtist(unknownArtisMbid)

--- a/app/src/test/java/com/antonioleiva/bandhookkotlin/data/mock/FakeCall.kt
+++ b/app/src/test/java/com/antonioleiva/bandhookkotlin/data/mock/FakeCall.kt
@@ -1,0 +1,64 @@
+package com.antonioleiva.bandhookkotlin.data.mock
+
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+import okhttp3.Request
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+/**
+ * Created by Mahmoud Abdurrahman (ma.abdurrahman@gmail.com) on 2/17/17.
+ *
+ * Pulled from: https://github.com/square/retrofit/blob/master/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
+ */
+class FakeCall<T>(val response: Response<T>?, val error: IOException?) : Call<T> {
+    val canceled = AtomicBoolean()
+    val executed = AtomicBoolean()
+
+    init {
+        if ((response == null) == (error == null)) {
+            throw AssertionError("Only one of response or error can be set.")
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun execute(): Response<T> {
+        if (!executed.compareAndSet(false, true)) {
+            throw IllegalStateException("Already executed")
+        }
+        if (canceled.get()) {
+            throw IOException("canceled")
+        }
+        if (response != null) {
+            return response
+        }
+        error?.let{ throw error } ?: throw IOException("Should either have a response or throw exception")
+    }
+
+    override fun enqueue(callback: Callback<T>?) {
+        if (!executed.compareAndSet(false, true)) {
+            throw IllegalStateException("Already executed")
+        }
+        callback?.let {
+            if (canceled.get()) {
+                callback.onFailure(this, IOException("canceled"))
+            } else if (response != null) {
+                callback.onResponse(this, response)
+            } else {
+                callback.onFailure(this, error)
+            }
+        } ?: throw NullPointerException("callback == null")
+    }
+
+    override fun isExecuted(): Boolean = executed.get()
+
+    override fun cancel() = canceled.set(true)
+
+    override fun isCanceled(): Boolean = canceled.get()
+
+    override fun clone(): Call<T> = FakeCall(response, error)
+
+    override fun request(): Request = response?.raw()?.request() ?: Request.Builder().url("http://localhost").build()
+}


### PR DESCRIPTION
Fixed Retrofit 2 service mocking having invalid return type in Unit Tests, it was implemented to return the expected deserialized response directly, however, it should return a Retrofit Call<?> type of the response, thus I pulled a Fake implementation of Retrofit Call<?> (from: https://github.com/square/retrofit/blob/master/retrofit-mock/src/main/java/retrofit2/mock/Calls.java) where it's initialized using either a Response (i.e. success, error) or IOException to simulate network issues if required